### PR TITLE
fixed bug, not being able to write code on the first line

### DIFF
--- a/pybash/hook.py
+++ b/pybash/hook.py
@@ -5,7 +5,7 @@ from pybash.transformer import transform
 
 def source_init():
     """Adds subprocess import"""
-    return "import subprocess"
+    return "import subprocess\n"
 
 
 def add_hook():


### PR DESCRIPTION
Hello, first of all this is my first pull request. (Sorry if I dont really know what I'm doing)
Second of all, pybash currently gets a syntax error anytime it parses a file that has code on the first line, this is because of this line in import_hook.py:
```py
180         if self.source_init is not None:
181             source = self.source_init() + source
```
Its basically doing `"import subprocess" + source`, which concatenates the import line and the first line of the code.
I changed it to `"import subprocess\n"` so that the import stays on its own line.

p.s. your project is really cool, thanks for making it  :)